### PR TITLE
Add customizable lives

### DIFF
--- a/Conjugator/Models/Level.swift
+++ b/Conjugator/Models/Level.swift
@@ -63,7 +63,11 @@ extension Level {
                 case "lives":
                     if let value = values[safe: 1] {
                         if value.isNumber {
-                            let valueInt = Int(value) ?? 3
+                            var valueInt = Int(value) ?? 3
+                            if valueInt < 0 || valueInt > 10 {
+                                valueInt = 3
+                            }
+                            
                             if valueInt == 0 {
                                 level.livesMode = .suddenDeath
                             } else {

--- a/Conjugator/Models/Level.swift
+++ b/Conjugator/Models/Level.swift
@@ -60,8 +60,19 @@ extension Level {
                     }
                 case "randomization_mode":
                     break
-                case "lives_mode":
-                    break
+                case "lives":
+                    if let value = values[safe: 1] {
+                        if value.isNumber {
+                            let valueInt = Int(value) ?? 3
+                            if valueInt == 0 {
+                                level.livesMode = .suddenDeath
+                            } else {
+                                level.livesMode = .fixed(valueInt)
+                            }
+                        } else if value == "-" {
+                            level.livesMode = .unlimited
+                        }
+                    }
                 case "word":
                     if let verb = values[safe: 1] {
                         let verbForms = Array(values.dropFirst(2)) /// remove the "Word" label and the first value (which is the verb)

--- a/Conjugator/Utilities.swift
+++ b/Conjugator/Utilities.swift
@@ -189,6 +189,12 @@ extension Collection {
     }
 }
 
+extension String {
+    var isNumber: Bool {
+        return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+    }
+}
+
 /// From https://gist.github.com/IanKeen/4d29b48519dca125b21675eeb7623d60
 import SwiftUI
 @propertyWrapper


### PR DESCRIPTION
Requires optional `Lives` row in level configuration

- number: customizable lives (maximum of 10)
  - `0`: sudden death
- `-`: unlimited